### PR TITLE
Added Item use delays to SO of each item separately

### DIFF
--- a/Assets/Failsafe/Entites/Items/!Common/Scripts/IUsable.cs
+++ b/Assets/Failsafe/Entites/Items/!Common/Scripts/IUsable.cs
@@ -9,5 +9,7 @@ namespace Failsafe.Items
         /// Использовать
         /// </summary>
         public ItemUseResult Use();
+
+        public void GetItemUseDelays(out float startDelay, out float useDelay);
     }
 }

--- a/Assets/Failsafe/Entites/Items/Adrenaline/Scripts/Adrenaline.cs
+++ b/Assets/Failsafe/Entites/Items/Adrenaline/Scripts/Adrenaline.cs
@@ -28,6 +28,12 @@ namespace Failsafe.Items
             return ItemUseResult.Consumed;
         }
 
+        public void GetItemUseDelays(out float startUseDelay, out float useDelay)
+        {
+            startUseDelay = _data.StartUseDelay;
+            useDelay = _data.UseDelay;
+        }
+
         //TODO: Вынести в отдельный файл если эффект будет переиспользоваться другими предметами
         public class AdrenalineEffect : Effect
         {

--- a/Assets/Failsafe/Entites/Items/Adrenaline/Scripts/AdrenalineData.cs
+++ b/Assets/Failsafe/Entites/Items/Adrenaline/Scripts/AdrenalineData.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace Failsafe.Items
 {
@@ -7,5 +7,14 @@ namespace Failsafe.Items
     {
         public float SpeedMultiplier;
         public float Duration;
+
+        /// <summary>
+        /// Время с момента использования предмета (например, нажатия кнопки) до срабатывания его эффекта (Нужно для синхронизации анимации, геймплея и звука)
+        /// </summary>
+        public float StartUseDelay;
+        /// <summary>
+        /// Кулдаун изпользования предмета
+        /// </summary>
+        public float UseDelay;
     }
 }

--- a/Assets/Failsafe/Entites/Items/Gorilla/Scripts/Gorilla.cs
+++ b/Assets/Failsafe/Entites/Items/Gorilla/Scripts/Gorilla.cs
@@ -26,6 +26,12 @@ namespace Failsafe.Items
             _effectManager.ApplyEffect(_effect);
             return ItemUseResult.Consumed;
         }
+
+        public void GetItemUseDelays(out float startUseDelay, out float useDelay)
+        {
+            startUseDelay = _data.StartUseDelay;
+            useDelay = _data.UseDelay;
+        }
     }
 
     public class GorillaEffect : Effect

--- a/Assets/Failsafe/Entites/Items/Gorilla/Scripts/GorillaData.cs
+++ b/Assets/Failsafe/Entites/Items/Gorilla/Scripts/GorillaData.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace Failsafe.Items
 {
@@ -7,5 +7,14 @@ namespace Failsafe.Items
     {
         public float ThrowPowerMultiplier;
         public float Duration;
+
+        /// <summary>
+        /// Время с момента использования предмета (например, нажатия кнопки) до срабатывания его эффекта (Нужно для синхронизации анимации, геймплея и звука)
+        /// </summary>
+        public float StartUseDelay;
+        /// <summary>
+        /// Кулдаун изпользования предмета
+        /// </summary>
+        public float UseDelay;
     }
 }

--- a/Assets/Failsafe/Entites/Items/StasisGun/Data/StasisGunData.asset
+++ b/Assets/Failsafe/Entites/Items/StasisGun/Data/StasisGunData.asset
@@ -15,3 +15,5 @@ MonoBehaviour:
   StasisDuration: 10
   FireRate: 1
   ChargeAmountMax: 10
+  StartUseDelay: 0.5
+  UseDelay: 0.3

--- a/Assets/Failsafe/Entites/Items/StasisGun/Scripts/StasisGun.cs
+++ b/Assets/Failsafe/Entites/Items/StasisGun/Scripts/StasisGun.cs
@@ -115,7 +115,11 @@ namespace Failsafe.Items
             return hit;
         }
 
-
+        public void GetItemUseDelays(out float startUseDelay, out float useDelay)
+        {
+            startUseDelay = _data.StartUseDelay;
+            useDelay = _data.UseDelay;
+        }
     }
 
 }

--- a/Assets/Failsafe/Entites/Items/StasisGun/Scripts/StasisGunData.cs
+++ b/Assets/Failsafe/Entites/Items/StasisGun/Scripts/StasisGunData.cs
@@ -1,9 +1,17 @@
-using UnityEngine;
+﻿using UnityEngine;
 [CreateAssetMenu(fileName = "StasisGunData", menuName = "ScriptableObjects/Entities/Items/Components/StasisGunData")]
 public class StasisGunData : ScriptableObject
 {
     public float StasisDuration;
     public float FireRate;
     public int ChargeAmountMax;
-    
+
+    /// <summary>
+    /// Время с момента использования предмета (например, нажатия кнопки) до срабатывания его эффекта (Нужно для синхронизации анимации, геймплея и звука)
+    /// </summary>
+    public float StartUseDelay;
+    /// <summary>
+    /// Кулдаун изпользования предмета
+    /// </summary>
+    public float UseDelay;
 }

--- a/Assets/Failsafe/Entites/Items/Stimpack/Scripts/Stimpack.cs
+++ b/Assets/Failsafe/Entites/Items/Stimpack/Scripts/Stimpack.cs
@@ -22,5 +22,11 @@ namespace Failsafe.Items
             _playerHealth.ModifyMaxHealth(_maxHealthModificator);
             return ItemUseResult.Consumed;
         }
+
+        public void GetItemUseDelays(out float startUseDelay, out float useDelay)
+        {
+            startUseDelay = _data.StartUseDelay;
+            useDelay = _data.UseDelay;
+        }
     }
 }

--- a/Assets/Failsafe/Entites/Items/Stimpack/Scripts/StimpackData.cs
+++ b/Assets/Failsafe/Entites/Items/Stimpack/Scripts/StimpackData.cs
@@ -13,5 +13,14 @@ namespace Failsafe.Items
         /// На сколько увеличивается максимальное здоровье
         /// </summary>
         public float MaxHealthBonus;
+
+        /// <summary>
+        /// Время с момента использования предмета (например, нажатия кнопки) до срабатывания его эффекта (Нужно для синхронизации анимации, гейплея и звука)
+        /// </summary>
+        public float StartUseDelay;
+        /// <summary>
+        /// Кулдаун изпользования предмета
+        /// </summary>
+        public float UseDelay;
     }
 }

--- a/Assets/Failsafe/Entites/Items/Tushkan/Scripts/Tushkan.cs
+++ b/Assets/Failsafe/Entites/Items/Tushkan/Scripts/Tushkan.cs
@@ -29,7 +29,11 @@ namespace Failsafe.Items
             return ItemUseResult.Consumed;
         }
 
-
+        public void GetItemUseDelays(out float startUseDelay, out float useDelay)
+        {
+            startUseDelay = _data.StartUseDelay;
+            useDelay = _data.UseDelay;
+        }
     }
 
     public class TushkanEffect : Effect

--- a/Assets/Failsafe/Entites/Items/Tushkan/Scripts/TushkanData.cs
+++ b/Assets/Failsafe/Entites/Items/Tushkan/Scripts/TushkanData.cs
@@ -7,5 +7,14 @@ namespace Failsafe.Items
     {
         public float JumpMultiplier;
         public float Duration;
+
+        /// <summary>
+        /// Время с момента использования предмета (например, нажатия кнопки) до срабатывания его эффекта (Нужно для синхронизации анимации, гейплея и звука)
+        /// </summary>
+        public float StartUseDelay;
+        /// <summary>
+        /// Кулдаун изпользования предмета
+        /// </summary>
+        public float UseDelay;
     }
 }

--- a/Assets/Failsafe/Player/Scripts/Items/PlayerHandsContainer.cs
+++ b/Assets/Failsafe/Player/Scripts/Items/PlayerHandsContainer.cs
@@ -32,6 +32,17 @@ public class PlayerHandsContainer
     private IEnumerable<IUsable> _items;
     private Transform _rightHandItemPlace;
 
+    // Задержка после применения предмета, чтобы не спамить использование предметов
+    // Примерно должен соответсвовать времени анимаций, но не обязательно
+    // Если у разных предметов должны быть разные кулдауны, то вынести это в ItemData
+    private float _itemUseDelay = 0f;
+    public float ItemUseDelay => _itemUseDelay;
+    // Время использования одного предмета. По сути время анимации использования
+    // Нужно чтобы Эффект предмета/визуал/звук сработал в определенный момент анимации, а не сразу при нажатии кнопки
+    // Сейчас задается один на всех, нужно будет вынести в предмет и настраивать для каждого свой
+    private float _itemUseStartDelay = 0f;
+    public float ItemUseStartDelay => _itemUseStartDelay;
+
     public PlayerHandsContainer(IEnumerable<IUsable> items, PlayerView playerView)
     {
         _items = items;
@@ -67,6 +78,7 @@ public class PlayerHandsContainer
         };
         _itemInHand = itemInHand;
         _handState = HandState.ItemInHand;
+        _itemInHand.ItemUsable.GetItemUseDelays(out _itemUseStartDelay, out _itemUseDelay);
         Debug.Log("Предмет взят в руку");
         OnItemTaked?.Invoke();
         return true;

--- a/Assets/Failsafe/Player/Scripts/Items/PlayerHandsSystem.cs
+++ b/Assets/Failsafe/Player/Scripts/Items/PlayerHandsSystem.cs
@@ -22,14 +22,6 @@ public class PlayerHandsSystem : ITickable
     private UsingState _usingState = UsingState.None;
     private Dictionary<ItemType, IActionWithItem> _actionsWithItems;
 
-    // Задержка после применения предмета, чтобы не спамить использование предметов
-    // Примерно должен соответсвовать времени анимаций, но не обязательно
-    // Если у разных предметов должны быть разные кулдауны, то вынести это в ItemData
-    [SerializeField] private float _itemUseDelay = 5f;
-    // Время использования одного предмета. По сути время анимации использования
-    // Нужно чтобы Эффект предмета/визуал/звук сработал в определенный момент анимации, а не сразу при нажатии кнопки
-    // Сейчас задается один на всех, нужно будет вынести в предмет и настраивать для каждого свой
-    [SerializeField] private float _itemUseStartDelay = 5f;
     // Пропускать начальную анимацию при повторном применении, скорее всего нужно вынести в параметры предмета или в UseResult
     private bool _skipStartDelay;
 
@@ -91,7 +83,7 @@ public class PlayerHandsSystem : ITickable
 
             OnItemStartUsing?.Invoke(_itemInHandType);
             _usingState = UsingState.Start;
-            await UniTask.Delay(TimeSpan.FromSeconds(_itemUseStartDelay));
+            await UniTask.Delay(TimeSpan.FromSeconds(_playerHandsContainer.ItemUseStartDelay));
         }
         _usingState = UsingState.Using;
 
@@ -102,7 +94,7 @@ public class PlayerHandsSystem : ITickable
             _skipStartDelay = false;
             _inputHandler.UseTrigger.ReleaseTrigger();
             _usingState = UsingState.OnDelay;
-            await UniTask.Delay(TimeSpan.FromSeconds(_itemUseDelay));
+            await UniTask.Delay(TimeSpan.FromSeconds(_playerHandsContainer.ItemUseDelay));
             _usingState = UsingState.None;
         }
         else if (useResult.UsageType == UsageType.HoldToUse)


### PR DESCRIPTION
Добавил ItemStartUseDelay и ItemUseDelay в ScriptableObject каждого предметы отдельно. Параметры обновляются при взятии предмета в руки. Можно потестить на сцене Datacenter указав в стазис гане и горилле большие/малые значения и проверить консоль. При высоких значениях задержки в консоль будет сыпать много сообщений о невозможности испльзовать предмет и анимация будет срабатывать гораздо позже.